### PR TITLE
v.2.10.2: Update mainnet references for Aztec node 4.1.3

### DIFF
--- a/aztec-logs.sh
+++ b/aztec-logs.sh
@@ -2169,7 +2169,7 @@ init_languages() {
   TRANSLATIONS["tr,claim_function_not_activated"]="Şu anda kontratta talep işlevi etkinleştirilmemiş"
 }
 
-SCRIPT_VERSION="2.10.1"
+SCRIPT_VERSION="2.10.2"
 ERROR_DEFINITIONS_VERSION="1.0.1"
 
 # Determine script directory for local file access (security: avoid remote code execution)
@@ -2182,7 +2182,7 @@ CONTRACT_ADDRESS="0xf6D0D42aCE06829bECB78C74F49879528fC632c1"  # Testnet 4.1.0 r
 #CONTRACT_ADDRESS="0x66a41cb55f9a1e38a45a2ac8685f12a61fbfab77"  # Testnet 3.0.3 rollup address
 #CONTRACT_ADDRESS="0xebd99ff0ff6677205509ae73f93d0ca52ac85d67"  # Testnet current rollup address
 #CONTRACT_ADDRESS_MAINNET="0x603bb2c05d474794ea97805e8de69bccfb3bca12"  # Mainnet 2.1.11 rollup address
-CONTRACT_ADDRESS_MAINNET="0xae2001f7e21d5ecabf6234e9fdd1e76f50f74962"  # Mainnet 4.1.2 rollup address
+CONTRACT_ADDRESS_MAINNET="0xae2001f7e21d5ecabf6234e9fdd1e76f50f74962"  # Mainnet 4.1.3 rollup address
 
 # GSE contract addresses
 GSE_ADDRESS_TESTNET="0xb6a38a51a6c1de9012f9d8ea9745ef957212eaac" # Testnet new GSE address

--- a/other/aztec-logs-dev.sh
+++ b/other/aztec-logs-dev.sh
@@ -2182,7 +2182,7 @@
   #CONTRACT_ADDRESS="0x66a41cb55f9a1e38a45a2ac8685f12a61fbfab77"  # Testnet 3.0.3 rollup address
   #CONTRACT_ADDRESS="0xebd99ff0ff6677205509ae73f93d0ca52ac85d67"  # Testnet current rollup address
   #CONTRACT_ADDRESS_MAINNET="0x603bb2c05d474794ea97805e8de69bccfb3bca12"  # Mainnet 2.1.11 rollup address
-  CONTRACT_ADDRESS_MAINNET="0xae2001f7e21d5ecabf6234e9fdd1e76f50f74962"  # Mainnet 4.1.2 rollup address
+  CONTRACT_ADDRESS_MAINNET="0xae2001f7e21d5ecabf6234e9fdd1e76f50f74962"  # Mainnet 4.1.3 rollup address
 
   # GSE contract addresses
   GSE_ADDRESS_TESTNET="0xb6a38a51a6c1de9012f9d8ea9745ef957212eaac" # Testnet new GSE address

--- a/other/version_control.json
+++ b/other/version_control.json
@@ -349,5 +349,12 @@
       "Fixed CheckpointProposed event TOPIC0 signature — incorrect value caused L1 verification to fail"
     ],
     "NOTICE": "After updating the script, remove the old monitoring agent and install a new one."
+  },
+  {
+    "VERSION": "2.10.2",
+    "UPDATE_DATE": "06.04.2026",
+    "CHANGES": [
+      "Updated mainnet version references from Aztec node 4.1.2 to 4.1.3"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- Bumped `SCRIPT_VERSION` from `2.10.1` to `2.10.2`
- Updated mainnet rollup contract address comments from Aztec node `4.1.2` to `4.1.3` in `aztec-logs.sh` and `other/aztec-logs-dev.sh`
- Added `2.10.2` entry to `other/version_control.json`
- Contract addresses (`CONTRACT_ADDRESS_MAINNET`, `GSE_ADDRESS_MAINNET`) and event topics are unchanged between patch versions

## Test plan
- [x] `other/version_control.json` passes `python3 -m json.tool` validation
- [x] No stale `4.1.2` references remain (only the changelog description mentioning the old version)
- [x] Diff is minimal and comment-only (no behavioral changes)